### PR TITLE
Feature 30 enable selecting projects to import over api

### DIFF
--- a/inception_reports/generate_reports_manager.py
+++ b/inception_reports/generate_reports_manager.py
@@ -227,7 +227,7 @@ def select_method_to_import_data():
             "Please input the path to the folder containing the INCEpTION projects."
         )
         projects_folder = st.sidebar.text_input(
-            "Projects Folder:", value="data/gemtex_demo_projects/"
+            "Projects Folder:", value=""
         )
         button = st.sidebar.button("Generate Reports")
         if button:

--- a/inception_reports/generate_reports_manager.py
+++ b/inception_reports/generate_reports_manager.py
@@ -231,12 +231,12 @@ def select_method_to_import_data():
         )
         button = st.sidebar.button("Generate Reports")
         if button:
-            st.session_state["initialized"] = True
             st.session_state["method"] = "Manually"
             st.session_state["projects"] = read_dir(projects_folder)
             button = False
             set_sidebar_state("collapsed")
     elif method == "API":
+        projects_folder = f"{os.path.expanduser('~')}/.inception_reports/projects"
         api_url = st.sidebar.text_input("Enter API URL:", "")
         username = st.sidebar.text_input("Username:", "")
         password = st.sidebar.text_input("Password:", type="password", value="")
@@ -252,11 +252,10 @@ def select_method_to_import_data():
                     inception_project, "jsoncas"
                 )
                 with open(
-                    f"{os.path.expanduser('~')}/.inception_reports/projects/{inception_project}.zip",
+                    f"{projects_folder}/{inception_project}.zip",
                     "wb",
                 ) as f:
                     f.write(project_export)
-            st.session_state["initialized"] = True
             st.session_state["method"] = "API"
             st.session_state["projects"] = read_dir(projects_folder)
             set_sidebar_state("collapsed")


### PR DESCRIPTION
**What's in the PR**
- Solves #30 
- Create checkboxes to select projects to import.
- Use streamlit state session to keep track of select projects.
- Minor UI fix for height of plots.
- Only generate reports for the selected projects, disregard other projects imported previously

**How to test manually**
- Run script.
- Choose API method for importing projects.
- Import some projects.

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
