### PR TITLE
Feature 46 add plotting token status to lead view

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "inception_reports"
 description = "Generate plots that report the progress of an INCEpTION project."
-version = "0.5.1"
+version = "0.6"
 authors = [
     { name = "Serwar", email = "serwar.basch@tu-darmstadt.de" }
 ]

--- a/tests/test_generate_reports_lead.py
+++ b/tests/test_generate_reports_lead.py
@@ -17,13 +17,17 @@
 import os
 from unittest.mock import MagicMock, patch
 
-from inception_reports.generate_reports_lead import get_unique_tags, plot_multiples, read_dir
+from inception_reports.generate_reports_lead import (
+    get_unique_tags,
+    plot_multiples,
+    read_dir,
+)
 
 
 def test_get_unique_tags():
     """
     Test case for the get_unique_tags function.
-    
+
     This test case verifies that the get_unique_tags function returns the expected result
     when given a list of projects with tags.
     """
@@ -105,6 +109,14 @@ def test_plot_project_progress():
             "CURATION_FINISHED": 0,
             "NEW": 4,
         },
+        "doc_token_categories": {
+            "ANNOTATION_IN_PROGRESS": 13339,
+            "ANNOTATION_FINISHED": 0,
+            "CURATION_IN_PROGRESS": 8092,
+            "CURATION_FINISHED": 0,
+            "NEW": 0,
+        },
+        "created": "2024-06-11",
     }
 
     plot_multiples([project_data], ["tag1", "tag2", "tag3"])

--- a/tests/test_generate_reports_manager.py
+++ b/tests/test_generate_reports_manager.py
@@ -87,13 +87,14 @@ def test_export_data(tmpdir):
             "CURATION_IN_PROGRESS": 3,
             "CURATION_FINISHED": 7,
         },
+        "created": "2024-06-11"
     }
 
     current_date = datetime.now().strftime("%Y_%m_%d")
     output_directory = tmpdir.mkdir("output")
     export_data(project_data, output_directory)
 
-    expected_file_path = os.path.join(output_directory, f"exported_data_{current_date}/{project_data['project_name']}_data_{current_date}.json")
+    expected_file_path = os.path.join(output_directory, f"exported_data_{current_date}/{project_data['project_name']}_{current_date}.json")
     assert os.path.exists(expected_file_path)
 
     with open(expected_file_path, "r") as output_file:


### PR DESCRIPTION
**What's in the PR**
- Implemented same functionality as #36 
- Handling of project without tags. Currently, they get omitted from plotting, and the user gets a warning.
- Adjust unit test to changes
- Bump up package version

**How to test manually**
* Run script in lead mode (--lead)
* Import some project progress data that contain token status
* Admire multi-functionality pie charts.

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
