### PR TITLE
#60 - Fix wide mode

### DIFF
--- a/inception_reports/generate_reports_manager.py
+++ b/inception_reports/generate_reports_manager.py
@@ -37,7 +37,7 @@ from pycaprio import Pycaprio
 
 st.set_page_config(
     page_title="INCEpTION Reporting Dashboard",
-    layout="centered",
+    layout="wide",
     initial_sidebar_state=st.session_state.setdefault("sidebar_state", "expanded"),
 )
 


### PR DESCRIPTION
**What's in the PR**
- Solved #60 by changing the layout in page config to wide

**How to test manually**
* Start the Dashboard in a freshly installed environment, and generate some reports. The plots should be displayed using the entire width of the page.

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
