### PR TITLE
75 missing output directory option

### DIFF
--- a/inception_reports/__main__.py
+++ b/inception_reports/__main__.py
@@ -23,28 +23,33 @@ import logging.config
 import yaml
 import importlib
 
-def setup_logging(log_level: str = None,log_dir: str = None):
+
+def setup_logging(log_level: str = None, log_dir: str = None):
     """
     Sets up logging configuration.
 
     Args:
         log_level: The desired log level (e.g., "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL").
         log_dir: The directory where log files will be stored.
-    """        
+    """
     # Use importlib.resources to access logging_config.yaml
-    with importlib.resources.path('inception_reports.config', 'logging_config.yaml') as config_path:
+    with importlib.resources.path(
+        "inception_reports.config", "logging_config.yaml"
+    ) as config_path:
         # Read logging configuration from YAML file
-        with open(config_path, 'r') as file:
+        with open(config_path, "r") as file:
             logging_config = yaml.safe_load(file)
 
         # Override log level and directory if provided
-        log_level = log_level or os.getenv('INCEPTION_LOG_LEVEL', None)
-        log_dir = log_dir or os.getenv('INCEPTION_LOG_DIR', 'inception_reports_logs')
+        log_level = log_level or os.getenv("INCEPTION_LOG_LEVEL", None)
+        log_dir = log_dir or os.getenv("INCEPTION_LOG_DIR", "inception_reports_logs")
 
         # Override log file path
         if not os.path.exists(log_dir):
             os.makedirs(log_dir)
-        logging_config['handlers']['file']['filename'] = os.path.join(log_dir, 'app.log')
+        logging_config["handlers"]["file"]["filename"] = os.path.join(
+            log_dir, "app.log"
+        )
 
         # Apply logging configuration
         logging.config.dictConfig(logging_config)
@@ -54,21 +59,42 @@ def setup_logging(log_level: str = None,log_dir: str = None):
             logger = logging.getLogger()  # Root logger
             logger.setLevel(log_level.upper())
 
+
 def main():
     parser = argparse.ArgumentParser(
         description="Generate plots for your INCEpTION project."
     )
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument(
-        "-m", "--manager", help="You are managing a single project, or a single location.", action="store_true"
+        "-m",
+        "--manager",
+        help="You are managing a single project, or a single location.",
+        action="store_true",
     )
-    group.add_argument("-l", "--lead", help="You are leading multiple projects, or multiple locations.", action="store_true")
-    
-    parser.add_argument('--logger',choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],help='Set the logging level')
+    group.add_argument(
+        "-l",
+        "--lead",
+        help="You are leading multiple projects, or multiple locations.",
+        action="store_true",
+    )
+
+    parser.add_argument(
+        "-o", "--output", help="Output directory for the generated plots.", required=False
+    )
+
+    parser.add_argument(
+        "--logger",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Set the logging level",
+    )
     args = parser.parse_args()
 
     setup_logging(args.logger)
     log = logging.getLogger(__name__)
+
+    if args.output:
+        os.environ["INCEPTION_OUTPUT_DIR"] = args.output
+        print(f"Output directory set to: {args.output}")
 
     if args.manager:
         log.info("STARTING INCEpTION Reporting Dashboard - Manager")

--- a/inception_reports/generate_reports_manager.py
+++ b/inception_reports/generate_reports_manager.py
@@ -88,8 +88,7 @@ def startup():
                 f"A new version ({latest_version}) of {package_name} is available. "
                 f"You are currently using version ({current_version}). Please update the package."
             )
-    
-    st.session_state["output_directory"] = os.getenv("INCEPTION_OUTPUT_DIR")
+
 
 
 def get_project_info():
@@ -479,7 +478,7 @@ def get_type_counts(annotations):
     return type_count
 
 
-def export_data(project_data, output_directory=None):
+def export_data(project_data):
     """
     Export project data to a JSON file, and store it in a directory named after the project and the current date.
 
@@ -488,7 +487,7 @@ def export_data(project_data, output_directory=None):
     """
     current_date = datetime.now().strftime("%Y_%m_%d")
 
-    output_directory = st.session_state.get("output_directory", None)
+    output_directory = os.getenv("INCEPTION_OUTPUT_DIR")
 
     if output_directory is None:
         output_directory = os.path.join(os.getcwd(), "exported_project_data")
@@ -766,7 +765,7 @@ def plot_project_progress(project) -> None:
     with col3:
         st.plotly_chart(bar_chart, use_container_width=True)
 
-    export_data(project_data, st.session_state["projects_folder"])
+    export_data(project_data)
 
 
 def main():

--- a/inception_reports/generate_reports_manager.py
+++ b/inception_reports/generate_reports_manager.py
@@ -88,6 +88,8 @@ def startup():
                 f"A new version ({latest_version}) of {package_name} is available. "
                 f"You are currently using version ({current_version}). Please update the package."
             )
+    
+    st.session_state["output_directory"] = os.getenv("INCEPTION_OUTPUT_DIR")
 
 
 def get_project_info():
@@ -486,11 +488,11 @@ def export_data(project_data, output_directory=None):
     """
     current_date = datetime.now().strftime("%Y_%m_%d")
 
+    output_directory = st.session_state.get("output_directory", None)
+
     if output_directory is None:
         output_directory = os.path.join(os.getcwd(), "exported_project_data")
-    else:
-        output_directory = os.path.join(output_directory, "exported_project_data")
-
+    
     if not os.path.exists(output_directory):
         os.makedirs(output_directory)
 

--- a/tests/test_generate_reports_manager.py
+++ b/tests/test_generate_reports_manager.py
@@ -92,9 +92,11 @@ def test_export_data(tmpdir):
 
     current_date = datetime.now().strftime("%Y_%m_%d")
     output_directory = tmpdir.mkdir("output")
-    export_data(project_data, output_directory)
+    os.environ["INCEPTION_OUTPUT_DIR"] = str(output_directory)
+    export_data(project_data)
 
-    expected_file_path = os.path.join(output_directory, f"exported_project_data/{project_data['project_name']}_{current_date}.json")
+    expected_file_path = os.path.join(output_directory, f"{project_data['project_name']}_{current_date}.json")
+    print(expected_file_path)
     assert os.path.exists(expected_file_path)
 
     with open(expected_file_path, "r") as output_file:


### PR DESCRIPTION
**What's in the PR**
- Added argument to input the output directory over CLI
- Pass the input as environment var
- Read the environment variables to get output dir
- Fix the export data function to use the output dir
- Fix failing unit test

**How to test manually**
- Input an output directory when running the Dashboard
- After generating a report, the output should be stored in the given output directory 

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
