### PR TITLE
#116 - Wrong handling of certificates for API mode

### DIFF
--- a/inception_reports/generate.py
+++ b/inception_reports/generate.py
@@ -136,7 +136,9 @@ def login_to_inception(api_url, username, password, ca_bundle=None, verify_ssl=T
         api_url = f"http://{api_url}"
     button = st.sidebar.button("Login")
     if button:
-        inception_client = Pycaprio(api_url, (username, password), ca_bundle=ca_bundle, verify=verify_ssl)
+        inception_client = Pycaprio(api_url, (username, password))
+        session = inception_client.api.client.session
+        session.verify = ca_bundle if ca_bundle else verify_ssl
         try:
             inception_client.api.projects()
             st.sidebar.success("Login successful")

--- a/inception_reports/project_loader.py
+++ b/inception_reports/project_loader.py
@@ -144,6 +144,12 @@ class CustomSSLAdapter(HTTPAdapter):
         )
         return super().proxy_manager_for(proxy, **proxy_kwargs)
 
+    def __getstate__(self):
+        state = super().__getstate__()
+        state["ca_bundle"] = self.ca_bundle
+        state["verify_ssl"] = self.verify_ssl
+        return state
+
 
 def _create_ssl_context(
     ca_bundle: str | None = None,


### PR DESCRIPTION
**What's in the PR**
- Fix SSL verification handling in login function
- Add state management for CustomSSLAdapter to include ca_bundle and verify_ssl

**How to test manually**
* Import project over API
* No errors, and if you have semantic annotations, then they should get translated too 

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
